### PR TITLE
fix(nodes): update schema to allow ref on timeout and contentLength

### DIFF
--- a/src/core/workflow/nodes/formRequest.js
+++ b/src/core/workflow/nodes/formRequest.js
@@ -37,8 +37,12 @@ class FormRequestNode extends SystemTaskNode {
                 url: { oneOf: [{ type: "string" }, { type: "object" }] },
                 verb: { type: "string", enum: ["POST", "PUT"] },
                 headers: { type: "object" },
-                maxContentLength: { type: "integer" },
-                timeout: { type: "integer" },
+                maxContentLength: {
+                  oneOf: [{ type: "number" }, { type: "object" }],
+                },
+                timeout: {
+                  oneOf: [{ type: "number" }, { type: "object" }],
+                },
               },
             },
             valid_response_codes: {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: Fix the formRequest node schema to allow timeout and max content length to use $ commands.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., usage docs, etc.**:
```docs
NONE
```
