### PR TITLE
Feat/timer node

### DIFF
--- a/src/core/workflow/tests/unitary/blueprint_samples.js
+++ b/src/core/workflow/tests/unitary/blueprint_samples.js
@@ -1669,6 +1669,50 @@ blueprints_.timer = {
   environment: {},
 };
 
+blueprints_.timer_long = {
+  requirements: [],
+  prepare: [],
+  nodes: [
+    {
+      id: "1",
+      type: "Start",
+      name: "start  node",
+      parameters: {
+        input_schema: {},
+      },
+      next: "2",
+      lane_id: "1",
+    },
+    {
+      id: "2",
+      type: "SystemTask",
+      category: "timer",
+      name: "timer node",
+      parameters: {
+        input: {},
+        timeout: 10000,
+      },
+      next: "99",
+      lane_id: "1",
+    },
+    {
+      id: "99",
+      type: "Finish",
+      name: "finish node",
+      next: null,
+      lane_id: "1",
+    },
+  ],
+  lanes: [
+    {
+      id: "1",
+      name: "only_lane",
+      rule: lisp.return_true(),
+    },
+  ],
+  environment: {},
+};
+
 blueprints_.user_encrypt = {
   requirements: [],
   prepare: [],

--- a/src/engine/engine.js
+++ b/src/engine/engine.js
@@ -556,7 +556,6 @@ class Engine {
       return error
     }
 
-
     const process = await Process.fetch(process_id)
 
     if(process.status !== ProcessStatus.PENDING) {
@@ -580,20 +579,8 @@ class Engine {
       await timer_db.update({ active: false }).where({ resource_id: process.id })
     }
 
-    try {
-      emitter.emit("ENGINE.CONTINUE_PROCESS.WORKS", { process_id })
-      return await process.continue(result, actor_data);
-    } catch (err) {
-      const error = {
-        error: {
-          errorType: "continueProcessException",
-          message: err.toString(),
-        }
-      }
-
-      emitter.emit("ENGINE.CONTINUE_PROCESS.ERROR", error)
-      return error
-    }
+    emitter.emit("ENGINE.CONTINUE_PROCESS.WORKS", { process_id })
+    return await process.continue(result, actor_data);
   }
 }
 

--- a/src/engine/tests/unitary/engine.test.js
+++ b/src/engine/tests/unitary/engine.test.js
@@ -13,7 +13,7 @@ const { packages_ } = require("../../../core/workflow/tests/unitary/packages_sam
 const extra_nodes = require("../utils/extra_nodes");
 
 beforeEach(async () => {
-   await _clean();
+  await _clean();
 });
 
 afterAll(async () => {
@@ -290,14 +290,29 @@ describe('continueProcess', () => {
     let process = await createRunProcess(engine, workflow.id, actors_.simpleton);
     expect(process.status).toEqual(ProcessStatus.WAITING);
 
-    let msg;
-    try {
-      await engine.continueProcess(process.id, actors_.simpleton, { new_result: 1 })
-    } catch (err) {
-      msg = err.toString()
-    }
+    const process_continue = await engine.continueProcess(process.id, actors_.simpleton, { new_result: 1 })
 
-    expect(msg).toEqual(`Error: This process isn't PENDING status.`)
+    expect(process_continue).toEqual({
+      error: {
+        errorType: 'continueProcessInvalidStatus',
+        message: "This process isn't PENDING status."
+      }
+    })
+  });
+  test("continueProcess should return invalid process type", async () => {
+    const engine = new Engine(...settings.persist_options);
+    const workflow = await engine.saveWorkflow("sample", "sample", blueprints_.user_action);
+    let process = await createRunProcess(engine, workflow.id, actors_.simpleton);
+    expect(process.status).toEqual(ProcessStatus.WAITING);
+
+    const process_continue = await engine.continueProcess(123456, actors_.simpleton)
+
+    expect(process_continue).toEqual({
+      error: {
+        errorType: 'continueProcessInvalidType',
+        message: "Invalid process_id type"
+      }
+    })
   });
 })
 

--- a/src/engine/tests/unitary/engine.test.js
+++ b/src/engine/tests/unitary/engine.test.js
@@ -284,6 +284,21 @@ describe('continueProcess', () => {
 
     expect(continueStep._result).toEqual({ timeout: 10000, new_result: 1, step_number: 3 })
   });
+  test("continueProcess should return invalid process status", async () => {
+    const engine = new Engine(...settings.persist_options);
+    const workflow = await engine.saveWorkflow("sample", "sample", blueprints_.user_action);
+    let process = await createRunProcess(engine, workflow.id, actors_.simpleton);
+    expect(process.status).toEqual(ProcessStatus.WAITING);
+
+    let msg;
+    try {
+      await engine.continueProcess(process.id, actors_.simpleton, { new_result: 1 })
+    } catch (err) {
+      msg = err.toString()
+    }
+
+    expect(msg).toEqual(`Error: This process isn't PENDING status.`)
+  });
 })
 
 describe("abortProcess", () => {


### PR DESCRIPTION
Feature - expose continueProcess to engine

/kind feature

The purpose of the functionality is to allow a PENDING process on a timerNode to resume before the timer expires.

[usage] 
  - engine.continueProcess(process_id, actor_data, new_result)
