### PR TITLE
Feature/get types categories

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const { Cockpit } = require("./src/cockpit/cockpit");
 const Nodes = require("./src/core/workflow/nodes/index.js");
 const { nodefyFunction, nodefyClass } = require("./src/core/utils/nodefy");
 const { ProcessStatus } = require("./src/core/workflow/process_state");
-const { getNode, addSystemTaskCategory } = require("./src/core/utils/node_factory");
+const { getNode, addSystemTaskCategory, getNodeCategories, getNodeTypes } = require("./src/core/utils/node_factory");
 const { Validator } = require("./src/core/validators");
 const { prepare } = require("./src/core/utils/input");
 const { ENGINE_ID } = require("./src/core/workflow/process_state");
@@ -17,6 +17,8 @@ module.exports = {
   NodeUtils: {
     nodefyFunction: nodefyFunction,
     nodefyClass: nodefyClass,
+    getNodeTypes,
+    getNodeCategories,
   },
   ProcessStatus,
   getNode,

--- a/src/core/utils/tests/unitary/node_factory.test.js
+++ b/src/core/utils/tests/unitary/node_factory.test.js
@@ -6,6 +6,37 @@ const extra_nodes = require("../../../../engine/tests/utils/extra_nodes");
 const { minimal } = require("../../../workflow/nodes/examples/formRequest");
 
 describe("node factory", () => {
+  describe("getNodeTypes", () => {
+    test("should work", () => {
+      const response = node_factory.getNodeTypes();
+      expect(response).toBeDefined();
+      const types = Object.keys(response);
+      expect(types.length).toBe(7);
+      expect(response.start).toBeDefined();
+      expect(response.finish).toBeDefined();
+      expect(response.flow).toBeDefined();
+      expect(response.scripttask).toBeDefined();
+      expect(response.usertask).toBeDefined();
+      expect(response.systemtask).toBeDefined();
+      expect(response.subprocess).toBeDefined();
+    });
+  });
+
+  describe("getNodeCategories", () => {
+    test("should work", () => {
+      const response = node_factory.getNodeCategories();
+      expect(response).toBeDefined();
+      const types = Object.keys(response);
+      expect(types.length).toBe(6);
+      expect(response.http).toBeDefined();
+      expect(response.settobag).toBeDefined();
+      expect(response.timer).toBeDefined();
+      expect(response.startprocess).toBeDefined();
+      expect(response.abortprocess).toBeDefined();
+      expect(response.formrequest).toBeDefined();
+    });
+  });
+
   describe("getNode", () => {
     test("Missing type", () => {
       const node_spec = lodash.cloneDeep(node_samples.start);
@@ -130,7 +161,7 @@ describe("node factory", () => {
           category: "unknow",
         };
 
-        expect(() => node_factory.getNode(node_spec)).toThrowError("unknow category");
+        expect(() => node_factory.getNode(node_spec)).toThrowError("unknown category");
       });
     });
 
@@ -208,6 +239,15 @@ describe("node factory", () => {
 
       expect(node).toBeDefined();
       expect(node).toBeInstanceOf(custom_node);
+    });
+
+    test("should mutate getNodeCategories", () => {
+      const response = node_factory.getNodeCategories();
+      expect(response).toBeDefined();
+      const types = Object.keys(response);
+      expect(types.length).toBe(8);
+      expect(response.customcategory).toBeDefined();
+      expect(response.custom).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds 2 functions getNodeTypes and getNodeCategories so it is possible to identify the available types and categories for that specific engine.
Refactor the nodeFactory to use Objects instead of switches to select types and categories.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/fdte-dsd/community/contributors/dev/guide/release_notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
