### PR TITLE
124 fix submissão de activity quando o activity schema é um objeto vazio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "axios": "0.27.2",
         "delegates": "1.0.0",
         "dotenv": "16.0.2",
-        "eventemitter2": "6.4.7",
+        "eventemitter2": "6.4.8",
         "handlebars": "4.7.7",
         "jsum": "1.0.1",
         "knex": "2.3.0",
@@ -25,7 +25,7 @@
         "qs": "6.11.0",
         "traceparent": "1.0.0",
         "uuid": "8.3.2",
-        "winston": "3.8.1"
+        "winston": "3.8.2"
       },
       "devDependencies": {
         "@semantic-release/changelog": "6.0.1",
@@ -35,7 +35,7 @@
         "eslint": "8.23.0",
         "jest": "26.6.3",
         "readline-sync": "1.4.10",
-        "semantic-release": "^19.0.5"
+        "semantic-release": "19.0.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3870,9 +3870,9 @@
       }
     },
     "node_modules/eventemitter2": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
-      "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg=="
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.8.tgz",
+      "integrity": "sha512-pAJurPyD+Nj/pfz8m0usKF1RW0E9gfY4Dfdem2l6jZbqcZlK8SP93qUMCv9V9FgOn+GSZEW6qeaglpf/vQ9D5A=="
     },
     "node_modules/exec-sh": {
       "version": "0.3.6",
@@ -13126,10 +13126,11 @@
       "dev": true
     },
     "node_modules/winston": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.1.tgz",
-      "integrity": "sha512-r+6YAiCR4uI3N8eQNOg8k3P3PqwAm20cLKlzVD9E66Ch39+LZC+VH1UKf9JemQj2B3QoUHfKD7Poewn0Pr3Y1w==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
+      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
       "dependencies": {
+        "@colors/colors": "1.5.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
@@ -16340,9 +16341,9 @@
       "dev": true
     },
     "eventemitter2": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
-      "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg=="
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.8.tgz",
+      "integrity": "sha512-pAJurPyD+Nj/pfz8m0usKF1RW0E9gfY4Dfdem2l6jZbqcZlK8SP93qUMCv9V9FgOn+GSZEW6qeaglpf/vQ9D5A=="
     },
     "exec-sh": {
       "version": "0.3.6",
@@ -23229,10 +23230,11 @@
       "dev": true
     },
     "winston": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.1.tgz",
-      "integrity": "sha512-r+6YAiCR4uI3N8eQNOg8k3P3PqwAm20cLKlzVD9E66Ch39+LZC+VH1UKf9JemQj2B3QoUHfKD7Poewn0Pr3Y1w==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
+      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
       "requires": {
+        "@colors/colors": "1.5.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "axios": "0.27.2",
     "delegates": "1.0.0",
     "dotenv": "16.0.2",
-    "eventemitter2": "6.4.7",
+    "eventemitter2": "6.4.8",
     "handlebars": "4.7.7",
     "jsum": "1.0.1",
     "knex": "2.3.0",
@@ -19,7 +19,7 @@
     "qs": "6.11.0",
     "traceparent": "1.0.0",
     "uuid": "8.3.2",
-    "winston": "3.8.1"
+    "winston": "3.8.2"
   },
   "devDependencies": {
     "@semantic-release/changelog": "6.0.1",
@@ -29,7 +29,7 @@
     "eslint": "8.23.0",
     "jest": "26.6.3",
     "readline-sync": "1.4.10",
-    "semantic-release": "^19.0.5"
+    "semantic-release": "19.0.5"
   },
   "moduleNameMapper": {
     "axios": "./__mocks__/axios/index.js"

--- a/src/core/utils/ajvValidator.js
+++ b/src/core/utils/ajvValidator.js
@@ -6,7 +6,7 @@ const _ = require("lodash");
 
 // eslint-disable-next-line no-useless-escape
 const dateTimeRegex = new RegExp(
-  "^(19[0-9]{2}|2[0-9]{3})-(0[1-9]|1[012])-([123]0|[012][1-9]|31)[ /T/t]([01][0-9]|2[0-3]):([0-5][0-9])(?::([0-5][0-9]))?$"
+  "^(19\\d{2}|2\\d{3})-(0[1-9]|1[012])-([123]0|[012][1-9]|31)[ /T/t]([01]\\d|2[0-3]):([0-5]\\d)(?::([0-5]\\d))?$"
 );
 ajv.addFormat("dateTime", {
   validate: (dateTimeString) => dateTimeRegex.test(dateTimeString),
@@ -21,7 +21,7 @@ ajv.addFormat("cpf", {
     if (cpf.toString().length != 11 || /^(\d)\1{10}$/.test(cpf)) return false;
     var result = true;
     [9, 10].forEach(function (j) {
-      var sum = 0,
+      let sum = 0,
         r;
       cpf
         .split(/(?=)/)

--- a/src/core/utils/tests/unitary/ajvValidator.test.js
+++ b/src/core/utils/tests/unitary/ajvValidator.test.js
@@ -1,396 +1,129 @@
+const _ = require("lodash");
 const ajvValidator = require("../../ajvValidator");
+
+const mainSchema = {
+  type: "object",
+  properties: {
+    stringType: { type: "string" },
+    numberType: { type: "number" },
+    uuidType: { type: "string", format: "uuid" },
+    flavors: { type: "array" },
+    cpfType: { type: "string", format: "cpf" },
+    dateTimeType: { type: "string", format: "dateTime" },
+    dateType: { type: "string", format: "date" },
+  },
+};
 
 describe("validateSchema", () => {
   test("Throw error for invalid schema", () => {
-    const schema = {
-      type: "unknowType",
-    };
-
+    const schema = { type: "unknowType" };
     expect(() => ajvValidator.validateSchema(schema)).toThrowError();
   });
 
   test("No error for valid schema", () => {
-    const schema = {
-      type: "object",
-    };
-
-    expect(() => ajvValidator.validateSchema(schema)).not.toThrowError();
+    expect(() => ajvValidator.validateSchema(mainSchema)).not.toThrowError();
   });
 });
 
 describe("validateData", () => {
   test("Invalid schema", () => {
-    const schema = {
-      type: "unknowType",
-    };
-    const data = 99;
-    expect(() => ajvValidator.validateData(schema, data)).toThrowError("schema is invalid");
+    expect(() => ajvValidator.validateData({ type: "unknowType" }, 99)).toThrowError("schema is invalid");
   });
 
   test("Throws error with error message", () => {
-    const schema = {
-      type: "object",
-    };
-    const data = "input";
-    expect(() => ajvValidator.validateData(schema, data)).toThrowError("data must be object");
+    expect(() => ajvValidator.validateData(mainSchema, "input")).toThrowError("data must be object");
   });
 
   test("Throws error with all error messages", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        name: { type: "string" },
-        age: { type: "number" },
-      },
-    };
     const data = {
-      name: { firstName: "exampleName" },
-      age: "22",
+      stringType: { firstName: "exampleName" },
+      numberType: "22",
     };
     try {
-      ajvValidator.validateData(schema, data);
+      ajvValidator.validateData(mainSchema, data);
     } catch (error) {
-      expect(error.message).toMatch("data/name must be string");
-      expect(error.message).toMatch("data/age must be number");
+      expect(error.message).toMatch("data/stringType must be string");
+      expect(error.message).toMatch("data/numberType must be number");
     }
-  });
-
-  test("Validate uuid", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string", format: "uuid" },
-      },
-    };
-    const data = {
-      id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
-    };
-    const resultError = ajvValidator.validateData(schema, data);
-    expect(resultError).toBeUndefined();
-  });
-
-  test("Validate date-time", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        dataInicio: { type: "string", format: "date-time" },
-      },
-    };
-    const data = {
-      dataInicio: "2020-11-20T14:44:00.1234Z",
-    };
-    const resultError = ajvValidator.validateData(schema, data);
-    expect(resultError).toBeUndefined();
-  });
-
-  test("Validate dateTime", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        data: { type: "string", format: "dateTime" },
-      },
-    };
-    const data = {
-      data: "2020-11-20T14:44:00",
-    };
-    const resultError = ajvValidator.validateData(schema, data);
-    expect(resultError).toBeUndefined();
   });
 
   test("Fast validation date should not work", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        data: { type: "string", format: "date" },
-      },
-    };
-    const data = {
-      data: "2020-19-20",
-    };
+    const data = { dateType: "2020-19-20" };
     try {
-      ajvValidator.validateData(schema, data);
+      ajvValidator.validateData(mainSchema, data);
     } catch (resultError) {
       expect(resultError).toBeDefined();
     }
   });
 
-  test("Throw error with invalid cpf", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        data: { type: "string", format: "cpf" },
-      },
-    };
+  describe("custom formats", () => {
+    test("dateTime", () => {
+      const data = { data: "2020-11-20T14:44:00" };
+      const resultError = ajvValidator.validateData(mainSchema, data);
+      expect(resultError).toBeUndefined();
+    });
 
-    const data = {
-      cpf: "123.123.123-12",
-    };
-    try {
-      ajvValidator.validateData(schema, data);
-    } catch (resultError) {
-      expect(resultError).toBeDefined();
-    }
-  });
+    describe("cpf", () => {
+      test("Validate a valid cpf", () => {
+        const data = { cpfType: "825.566.405-02" };
+        const resultError = ajvValidator.validateData(mainSchema, data);
+        expect(resultError).toBeUndefined();
+      });
 
-  test("Validate cpf", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        data: { type: "string", format: "cpf" },
-      },
-    };
+      test("Throw error with invalid cpf", () => {
+        const data = { cpfType: "123.123.123-12" };
+        try {
+          ajvValidator.validateData(mainSchema, data);
+        } catch (resultError) {
+          expect(resultError).toBeDefined();
+        }
+      });
 
-    const data = {
-      cpf: "825.566.405-02",
-    };
-    const resultError = ajvValidator.validateData(schema, data);
-    expect(resultError).toBeUndefined();
-  });
-
-  test("Validate cpf in schema", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        cpf: { type: "string", format: "cpf" },
-      },
-      required: ["cpf"],
-    };
-    const data = {
-      cpf: "825.566.405-02",
-    };
-    const resultError = ajvValidator.validateResult(schema, data);
-    expect(resultError).toBeUndefined();
-  });
-
-  test("Throw error with letter in cpf in schema", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        cpf: { type: "string", format: "cpf" },
-      },
-      required: ["cpf"],
-    };
-    const data = {
-      cpf: "a825.566.405-02",
-    };
-    const resultError = ajvValidator.validateResult(schema, data);
-    expect(resultError).toBeDefined();
-    expect(resultError.message).toMatch('data/cpf must match format "cpf"');
-  });
-
-  test("Validate date properties", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string", format: "uuid" },
-        dataInicio: { type: "string", format: "date-time" },
-        dataFim: { type: "string", format: "date" },
-        nome: { type: "string", minLength: 3 },
-      },
-      required: ["id", "dataInicio", "dataFim", "nome"],
-    };
-    const data = {
-      id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
-      dataInicio: "2020-11-20T14:44:00.1234Z",
-      dataFim: "2020-11-21",
-      nome: "Didi",
-    };
-    const resultError = ajvValidator.validateData(schema, data);
-    expect(resultError).toBeUndefined();
-  });
-
-  test("Validate multiple properties", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string", format: "uuid" },
-        dataInicio: { type: "string", format: "date-time" },
-        dataFim: { type: "string", format: "date" },
-        nome: { type: "string", minLength: 3 },
-      },
-      required: ["id", "dataInicio", "dataFim", "nome"],
-    };
-    const data = {
-      id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
-      dataInicio: "2020-11-20T14:44:00.1234Z",
-      dataFim: "2020-11-21",
-      nome: "Didi",
-    };
-    const resultError = ajvValidator.validateData(schema, data);
-    expect(resultError).toBeUndefined();
-  });
-
-  test("Fails with missing nome parameter", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string", format: "uuid" },
-        dataInicio: { type: "string", format: "date-time" },
-        dataFim: { type: "string", format: "date" },
-        nome: { type: "string", minLength: 3 },
-      },
-      required: ["id", "dataInicio", "dataFim", "nome"],
-    };
-    const data = {
-      id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
-      dataInicio: "2020-11-20T14:44:00.1234Z",
-      dataFim: "2020-11-21",
-    };
-    try {
-      ajvValidator.validateData(schema, data);
-    } catch (error) {
-      expect(error).toBeDefined();
-      expect(error.message).toMatch("data must have required property 'nome'");
-    }
-  });
-
-  test("Fails with additional properties", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string", format: "uuid" },
-      },
-      required: ["id"],
-      additionalProperties: false,
-    };
-    const data = {
-      id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
-      nome: "Didi",
-    };
-    try {
-      ajvValidator.validateData(schema, data);
-    } catch (error) {
-      expect(error).toBeDefined();
-      expect(error.message).toMatch("data must NOT have additional properties");
-    }
-  });
-
-  test("Pass with additional properties", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string", format: "uuid" },
-      },
-      required: ["id"],
-      additionalProperties: true,
-    };
-    const data = {
-      id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
-      nome: "Didi",
-    };
-    const resultError = ajvValidator.validateData(schema, data);
-    expect(resultError).toBeUndefined();
+      test("Throw error with letter in cpf in schema", () => {
+        const data = { cpfType: "a825.566.405-02" };
+        const resultError = ajvValidator.validateResult(mainSchema, data);
+        expect(resultError).toBeDefined();
+        expect(resultError.message).toMatch('data/cpfType must match format "cpf"');
+      });
+    });
   });
 });
 
 describe("validateResult", () => {
   test("Valid schema with data.data", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string" },
-        qty: { type: "number" },
-        status: { type: "string" },
-        flavors: { type: "array" },
-        comments: { type: "string" },
-        createdAt: { type: "string", format: "date-time" },
-      },
-    };
     const data = {
       status: 201,
       data: {
-        id: "5",
-        createdAt: "2021-01-12T22:32:28.199Z",
-        qty: 1,
-        flavors: ["portuguesa"],
-        comments: "comentarios",
-        status: "pending",
+        stringType: "5",
+        numberType: 1,
+        arrayType: ["portuguesa"],
       },
     };
-
-    const resultError = ajvValidator.validateResult(schema, data);
-    expect(resultError).toBeUndefined();
-  });
-
-  test("Pass with required property id in data.data", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string" },
-        qty: { type: "number" },
-        status: { type: "string" },
-        flavors: { type: "array" },
-        comments: { type: "string" },
-        createdAt: { type: "string", format: "date-time" },
-      },
-      required: ["id"],
-    };
-    const data = {
-      status: 201,
-      data: {
-        id: "5",
-        createdAt: "2021-01-12T22:32:28.199Z",
-        qty: 1,
-        flavors: ["portuguesa"],
-        comments: "comentarios",
-        status: "pending",
-      },
-    };
-
-    const resultError = ajvValidator.validateResult(schema, data);
+    const resultError = ajvValidator.validateResult(mainSchema, data);
     expect(resultError).toBeUndefined();
   });
 
   test("Throw error without required property id in data.data", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string" },
-        qty: { type: "number" },
-        status: { type: "string" },
-        flavors: { type: "array" },
-        comments: { type: "string" },
-        createdAt: { type: "string", format: "date-time" },
-      },
-      required: ["id"],
-    };
+    const schema = _.cloneDeep(mainSchema);
+    schema.required = ["stringType"];
     const data = {
       status: 201,
       data: {
-        createdAt: "2021-01-12T22:32:28.199Z",
-        flavors: ["portuguesa"],
-        comments: "comentarios",
-        status: "pending",
+        numberType: 10,
+        arrayType: ["other"],
       },
     };
-
     const resultError = ajvValidator.validateResult(schema, data);
     expect(resultError).toBeDefined();
-    expect(resultError.message).toMatch("data must have required property 'id'");
+    expect(resultError.message).toMatch("data must have required property 'stringType'");
   });
 
   test("Valid schema with data only", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string" },
-        qty: { type: "number" },
-        status: { type: "string" },
-        flavors: { type: "array" },
-        comments: { type: "string" },
-        createdAt: { type: "string", format: "date-time" },
-      },
-    };
     const data = {
-      id: "5",
-      createdAt: "2021-01-12T22:32:28.199Z",
-      qty: 1,
-      flavors: ["portuguesa"],
-      comments: "comentarios",
-      status: "pending",
+      stringType: "any",
+      numberType: 2,
     };
-
-    const resultError = ajvValidator.validateResult(schema, data);
+    const resultError = ajvValidator.validateResult(mainSchema, data);
     expect(resultError).toBeUndefined();
   });
 
@@ -569,161 +302,65 @@ describe("validateTimeInterval", () => {
 
 describe("validateActivityManager", () => {
   test("Pass with a valid schema", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string" },
-        qty: { type: "number" },
-        status: { type: "string" },
-        flavors: { type: "array" },
-        comments: { type: "string" },
-        createdAt: { type: "string", format: "date-time" },
-      },
-    };
-
     const data = {
-      id: "5",
-      qty: 1,
-      status: "pending",
-      flavors: ["portuguesa"],
-      comments: "comentarios",
-      createdAt: "2021-01-12T22:32:28.199Z",
+      stringType: "string",
+      numberType: 8,
+      arrayType: ["one more"],
     };
 
-    const resultError = ajvValidator.validateActivityManager(schema, data);
+    const resultError = ajvValidator.validateActivityManager(mainSchema, data);
     expect(resultError).toBeUndefined();
   });
 
   test("Pass with an empty object", () => {
-    const schema = {};
-    const data = {
-      id: "5",
-      qty: 1,
-    };
-
-    const resultError = ajvValidator.validateActivityManager(schema, data);
+    const resultError = ajvValidator.validateActivityManager({}, { data: "any" });
     expect(resultError).toBeUndefined();
-  });
-
-  test("Throw error without required property id", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        id: { type: "string" },
-        qty: { type: "number" },
-        status: { type: "string" },
-        flavors: { type: "array" },
-        comments: { type: "string" },
-        createdAt: { type: "string", format: "date-time" },
-      },
-      required: ["id"],
-    };
-
-    const data = {
-      qty: 1,
-      status: "pending",
-      flavors: ["portuguesa"],
-      comments: "comentarios",
-      createdAt: "2021-01-12T22:32:28.199Z",
-    };
-
-    const resultError = () => ajvValidator.validateActivityManager(schema, data);
-    expect(resultError).toThrowError("data must have required property 'id'");
   });
 
   test("Should rebuild schema if no type object is defined", () => {
     const schema = {
       properties: {
         id: { type: "string" },
-        qty: { type: "number" },
-        status: { type: "string" },
-        flavors: { type: "array" },
-        comments: { type: "string" },
-        createdAt: { type: "string", format: "date-time" },
       },
     };
 
-    const data = {
-      id: "5",
-      qty: 1,
-      status: "pending",
-      flavors: ["portuguesa"],
-      comments: "comentarios",
-      createdAt: "2021-01-12T22:32:28.199Z",
-    };
+    const data = { id: "5" };
 
     const resultError = ajvValidator.validateActivityManager(schema, data);
     expect(resultError).toBeUndefined();
   });
 
-  test("Pass with required in nested items", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        input: {
-          type: "object",
-          properties: {
-            email: { type: "string", format: "email" },
-            password: { type: "string" },
-            save_password: { type: "boolean" },
-          },
-          required: ["email", "password"],
-        },
-      },
-      required: ["input"],
-    };
+  test("Should throw errors with a invalid data with a valid schema", () => {
     const data = {
-      input: {
-        email: "didi_moco@gmail.com",
-        password: "trapalhoes",
-        save_password: true,
-      },
+      numberType: "8",
     };
 
-    const resultError = ajvValidator.validateActivityManager(schema, data);
+    try {
+      ajvValidator.validateActivityManager(mainSchema, data);
+    } catch (resultError) {
+      expect(resultError).toBeDefined();
+    }
+  });
+
+  test("Pass with an empty object", () => {
+    const resultError = ajvValidator.validateActivityManager({}, { data: "any" });
+    expect(resultError).toBeUndefined();
+  });
+});
+
+describe("validateBlueprintParameters", () => {
+  test("should work with a valid schema", () => {
+    const parameters = { max_step_number: 8 };
+    const resultError = ajvValidator.validateBlueprintParameters(parameters);
     expect(resultError).toBeUndefined();
   });
 
-  test("Throw error with required in nested items", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        input: {
-          type: "object",
-          properties: {
-            email: { type: "string", format: "email" },
-            password: { type: "string" },
-            save_password: { type: "boolean" },
-          },
-          required: ["email", "password"],
-        },
-      },
-      required: ["input"],
-    };
-    const data = {
-      input: {
-        email: "didi_moco@gmail.com",
-        save_password: true,
-      },
-    };
-
-    const resultError = () => ajvValidator.validateActivityManager(schema, data);
-    expect(resultError).toThrowError("data/input must have required property 'password'");
-  });
-
-  test("Throw error with date on format YYYY-1X-DD", async () => {
-    const schema = {
-      type: "object",
-      properties: {
-        dt: { type: "string", format: "date" },
-      },
-      required: ["dt"],
-    };
-    const data = {
-      dt: "2021-19-12",
-    };
-
-    const resultError = () => ajvValidator.validateActivityManager(schema, data);
-    expect(resultError).toThrowError('data/dt must match format "date"');
+  test("Should throw error with a invalid parameter", () => {
+    const parameters = { max_step_number: "any" };
+    try {
+      ajvValidator.validateBlueprintParameters(parameters);
+    } catch (resultError) {
+      expect(resultError).toBeDefined();
+    }
   });
 });

--- a/src/core/utils/tests/unitary/ajvValidator.test.js
+++ b/src/core/utils/tests/unitary/ajvValidator.test.js
@@ -90,6 +90,30 @@ describe("validateData", () => {
 });
 
 describe("validateResult", () => {
+  const nestedRequiredSchema = {
+    type: "object",
+    properties: {
+      input: {
+        type: "object",
+        properties: {
+          emailType: { type: "string", format: "email" },
+          stringType: { type: "string" },
+          booleanType: { type: "boolean" },
+        },
+        required: ["emailType", "booleanType"],
+      },
+    },
+    required: ["input"],
+  };
+
+  const testData = {
+    input: {
+      emailType: "didi_moco@gmail.com",
+      stringType: "trapalhoes",
+      booleanType: true,
+    },
+  };
+
   test("Valid schema with data.data", () => {
     const data = {
       status: 201,
@@ -179,89 +203,23 @@ describe("validateResult", () => {
   });
 
   test("Pass with required in nested items in data only", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        input: {
-          type: "object",
-          properties: {
-            email: { type: "string", format: "email" },
-            password: { type: "string" },
-            save_password: { type: "boolean" },
-          },
-          required: ["email", "password"],
-        },
-      },
-      required: ["input"],
-    };
-    const data = {
-      input: {
-        email: "didi_moco@gmail.com",
-        password: "trapalhoes",
-        save_password: true,
-      },
-    };
-
-    const resultError = ajvValidator.validateResult(schema, data);
+    const resultError = ajvValidator.validateResult(nestedRequiredSchema, testData);
     expect(resultError).toBeUndefined();
   });
 
   test("Pass with required in nested items in data data", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        input: {
-          type: "object",
-          properties: {
-            email: { type: "string", format: "email" },
-            password: { type: "string" },
-            save_password: { type: "boolean" },
-          },
-          required: ["email", "password"],
-        },
-      },
-      required: ["input"],
-    };
-    const data = {
-      data: {
-        input: {
-          email: "didi_moco@gmail.com",
-          password: "trapalhoes",
-          save_password: true,
-        },
-      },
-    };
-
-    const resultError = ajvValidator.validateResult(schema, data);
+    const data = { data: testData };
+    const resultError = ajvValidator.validateResult(nestedRequiredSchema, data);
     expect(resultError).toBeUndefined();
   });
 
   test("Throw error with required in nested items in data only", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        input: {
-          type: "object",
-          properties: {
-            email: { type: "string", format: "email" },
-            password: { type: "string" },
-            save_password: { type: "boolean" },
-          },
-          required: ["email", "password"],
-        },
-      },
-      required: ["input"],
-    };
-    const data = {
-      input: {
-        email: "didi_moco@gmail.com",
-        save_password: true,
-      },
-    };
+    const data = _.cloneDeep(testData);
+    delete data.input.emailType;
 
-    const resultError = ajvValidator.validateResult(schema, data);
+    const resultError = ajvValidator.validateResult(nestedRequiredSchema, data);
     expect(resultError).toBeDefined();
-    expect(resultError.message).toMatch("data/input must have required property 'password'");
+    expect(resultError.message).toMatch("data/input must have required property 'emailType'");
   });
 });
 

--- a/src/core/utils/tests/unitary/ajvValidator.test.js
+++ b/src/core/utils/tests/unitary/ajvValidator.test.js
@@ -11,25 +11,25 @@ describe("validateSchema", () => {
 
   test("No error for valid schema", () => {
     const schema = {
-      type: "object"
+      type: "object",
     };
 
     expect(() => ajvValidator.validateSchema(schema)).not.toThrowError();
   });
-})
+});
 
 describe("validateData", () => {
   test("Invalid schema", () => {
     const schema = {
       type: "unknowType",
-    }
+    };
     const data = 99;
     expect(() => ajvValidator.validateData(schema, data)).toThrowError("schema is invalid");
-  })
+  });
 
   test("Throws error with error message", () => {
     const schema = {
-      type: "object"
+      type: "object",
     };
     const data = "input";
     expect(() => ajvValidator.validateData(schema, data)).toThrowError("data must be object");
@@ -39,29 +39,29 @@ describe("validateData", () => {
     const schema = {
       type: "object",
       properties: {
-        name: {type: "string"},
-        age: {type: "number"}
-      }
+        name: { type: "string" },
+        age: { type: "number" },
+      },
     };
     const data = {
-      name: {firstName: "exampleName"},
+      name: { firstName: "exampleName" },
       age: "22",
     };
     try {
-      ajvValidator.validateData(schema, data)
+      ajvValidator.validateData(schema, data);
     } catch (error) {
       expect(error.message).toMatch("data/name must be string");
       expect(error.message).toMatch("data/age must be number");
     }
-  })
+  });
 
   test("Validate uuid", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string", format: "uuid"}
-      }
-    }
+        id: { type: "string", format: "uuid" },
+      },
+    };
     const data = {
       id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
     };
@@ -73,11 +73,11 @@ describe("validateData", () => {
     const schema = {
       type: "object",
       properties: {
-        dataInicio: {type: "string", format: "date-time"}
-      }
-    }
+        dataInicio: { type: "string", format: "date-time" },
+      },
+    };
     const data = {
-      dataInicio: "2020-11-20T14:44:00.1234Z"
+      dataInicio: "2020-11-20T14:44:00.1234Z",
     };
     const resultError = ajvValidator.validateData(schema, data);
     expect(resultError).toBeUndefined();
@@ -87,11 +87,11 @@ describe("validateData", () => {
     const schema = {
       type: "object",
       properties: {
-        data: {type: "string", format: "dateTime"}
-      }
-    }
+        data: { type: "string", format: "dateTime" },
+      },
+    };
     const data = {
-      data: "2020-11-20T14:44:00"
+      data: "2020-11-20T14:44:00",
     };
     const resultError = ajvValidator.validateData(schema, data);
     expect(resultError).toBeUndefined();
@@ -101,11 +101,11 @@ describe("validateData", () => {
     const schema = {
       type: "object",
       properties: {
-        data: {type: "string", format: "date"}
-      }
-    }
+        data: { type: "string", format: "date" },
+      },
+    };
     const data = {
-      data: "2020-19-20"
+      data: "2020-19-20",
     };
     try {
       ajvValidator.validateData(schema, data);
@@ -118,12 +118,12 @@ describe("validateData", () => {
     const schema = {
       type: "object",
       properties: {
-        data: {type: "string", format: "cpf"}
-      }
-    }
-        
+        data: { type: "string", format: "cpf" },
+      },
+    };
+
     const data = {
-      cpf: "123.123.123-12"
+      cpf: "123.123.123-12",
     };
     try {
       ajvValidator.validateData(schema, data);
@@ -132,18 +132,17 @@ describe("validateData", () => {
     }
   });
 
-
   test("Validate cpf", () => {
     const schema = {
       type: "object",
       properties: {
-        data: {type: "string", format: "cpf"}
-      }
-    }
+        data: { type: "string", format: "cpf" },
+      },
+    };
 
     const data = {
-      cpf: "825.566.405-02"
-    }
+      cpf: "825.566.405-02",
+    };
     const resultError = ajvValidator.validateData(schema, data);
     expect(resultError).toBeUndefined();
   });
@@ -152,12 +151,12 @@ describe("validateData", () => {
     const schema = {
       type: "object",
       properties: {
-        cpf: {type: "string", format: "cpf"},
+        cpf: { type: "string", format: "cpf" },
       },
-      required: ["cpf"]
-    }
+      required: ["cpf"],
+    };
     const data = {
-      cpf: '825.566.405-02'
+      cpf: "825.566.405-02",
     };
     const resultError = ajvValidator.validateResult(schema, data);
     expect(resultError).toBeUndefined();
@@ -167,35 +166,34 @@ describe("validateData", () => {
     const schema = {
       type: "object",
       properties: {
-        cpf: {type: "string", format: "cpf"},
+        cpf: { type: "string", format: "cpf" },
       },
-      required: ["cpf"]
-    }
+      required: ["cpf"],
+    };
     const data = {
-      cpf: 'a825.566.405-02'
+      cpf: "a825.566.405-02",
     };
     const resultError = ajvValidator.validateResult(schema, data);
     expect(resultError).toBeDefined();
-    expect(resultError.message).toMatch("data/cpf must match format \"cpf\"");
-
+    expect(resultError.message).toMatch('data/cpf must match format "cpf"');
   });
 
   test("Validate date properties", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string", format: "uuid"},
-        dataInicio: {type: "string", format: "date-time"},
-        dataFim: {type: "string", format: "date"},
-        nome: {type: "string", minLength: 3}
+        id: { type: "string", format: "uuid" },
+        dataInicio: { type: "string", format: "date-time" },
+        dataFim: { type: "string", format: "date" },
+        nome: { type: "string", minLength: 3 },
       },
-      required: ["id", "dataInicio", "dataFim", "nome"]
-    }
+      required: ["id", "dataInicio", "dataFim", "nome"],
+    };
     const data = {
       id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
       dataInicio: "2020-11-20T14:44:00.1234Z",
       dataFim: "2020-11-21",
-      nome: "Didi"
+      nome: "Didi",
     };
     const resultError = ajvValidator.validateData(schema, data);
     expect(resultError).toBeUndefined();
@@ -205,18 +203,18 @@ describe("validateData", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string", format: "uuid"},
-        dataInicio: {type: "string", format: "date-time"},
-        dataFim: {type: "string", format: "date"},
-        nome: {type: "string", minLength: 3}
+        id: { type: "string", format: "uuid" },
+        dataInicio: { type: "string", format: "date-time" },
+        dataFim: { type: "string", format: "date" },
+        nome: { type: "string", minLength: 3 },
       },
-      required: ["id", "dataInicio", "dataFim", "nome"]
-    }
+      required: ["id", "dataInicio", "dataFim", "nome"],
+    };
     const data = {
       id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
       dataInicio: "2020-11-20T14:44:00.1234Z",
       dataFim: "2020-11-21",
-      nome: "Didi"
+      nome: "Didi",
     };
     const resultError = ajvValidator.validateData(schema, data);
     expect(resultError).toBeUndefined();
@@ -226,20 +224,20 @@ describe("validateData", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string", format: "uuid"},
-        dataInicio: {type: "string", format: "date-time"},
-        dataFim: {type: "string", format: "date"},
-        nome: {type: "string", minLength: 3}
+        id: { type: "string", format: "uuid" },
+        dataInicio: { type: "string", format: "date-time" },
+        dataFim: { type: "string", format: "date" },
+        nome: { type: "string", minLength: 3 },
       },
-      required: ["id", "dataInicio", "dataFim", "nome"]
-    }
+      required: ["id", "dataInicio", "dataFim", "nome"],
+    };
     const data = {
       id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
       dataInicio: "2020-11-20T14:44:00.1234Z",
-      dataFim: "2020-11-21"
+      dataFim: "2020-11-21",
     };
     try {
-      ajvValidator.validateData(schema, data)
+      ajvValidator.validateData(schema, data);
     } catch (error) {
       expect(error).toBeDefined();
       expect(error.message).toMatch("data must have required property 'nome'");
@@ -250,17 +248,17 @@ describe("validateData", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string", format: "uuid"},
+        id: { type: "string", format: "uuid" },
       },
       required: ["id"],
-      additionalProperties: false
-    }
+      additionalProperties: false,
+    };
     const data = {
       id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
-      nome: "Didi"
+      nome: "Didi",
     };
     try {
-      ajvValidator.validateData(schema, data)
+      ajvValidator.validateData(schema, data);
     } catch (error) {
       expect(error).toBeDefined();
       expect(error.message).toMatch("data must NOT have additional properties");
@@ -271,31 +269,31 @@ describe("validateData", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string", format: "uuid"},
+        id: { type: "string", format: "uuid" },
       },
       required: ["id"],
-      additionalProperties: true
-    }
+      additionalProperties: true,
+    };
     const data = {
       id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
-      nome: "Didi"
+      nome: "Didi",
     };
     const resultError = ajvValidator.validateData(schema, data);
     expect(resultError).toBeUndefined();
   });
-})
+});
 
 describe("validateResult", () => {
   test("Valid schema with data.data", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string"},
-        qty: {type: "number"},
-        status: {type: "string"},
-        flavors: {type: "array"},
-        comments: {type: "string"},
-        createdAt: {type: "string", format: "date-time"}
+        id: { type: "string" },
+        qty: { type: "number" },
+        status: { type: "string" },
+        flavors: { type: "array" },
+        comments: { type: "string" },
+        createdAt: { type: "string", format: "date-time" },
       },
     };
     const data = {
@@ -304,12 +302,10 @@ describe("validateResult", () => {
         id: "5",
         createdAt: "2021-01-12T22:32:28.199Z",
         qty: 1,
-        flavors: [
-          "portuguesa"
-        ],
+        flavors: ["portuguesa"],
         comments: "comentarios",
-        status: "pending"
-      }
+        status: "pending",
+      },
     };
 
     const resultError = ajvValidator.validateResult(schema, data);
@@ -320,14 +316,14 @@ describe("validateResult", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string"},
-        qty: {type: "number"},
-        status: {type: "string"},
-        flavors: {type: "array"},
-        comments: {type: "string"},
-        createdAt: {type: "string", format: "date-time"}
+        id: { type: "string" },
+        qty: { type: "number" },
+        status: { type: "string" },
+        flavors: { type: "array" },
+        comments: { type: "string" },
+        createdAt: { type: "string", format: "date-time" },
       },
-      required: ["id"]
+      required: ["id"],
     };
     const data = {
       status: 201,
@@ -335,12 +331,10 @@ describe("validateResult", () => {
         id: "5",
         createdAt: "2021-01-12T22:32:28.199Z",
         qty: 1,
-        flavors: [
-          "portuguesa"
-        ],
+        flavors: ["portuguesa"],
         comments: "comentarios",
-        status: "pending"
-      }
+        status: "pending",
+      },
     };
 
     const resultError = ajvValidator.validateResult(schema, data);
@@ -351,25 +345,23 @@ describe("validateResult", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string"},
-        qty: {type: "number"},
-        status: {type: "string"},
-        flavors: {type: "array"},
-        comments: {type: "string"},
-        createdAt: {type: "string", format: "date-time"}
+        id: { type: "string" },
+        qty: { type: "number" },
+        status: { type: "string" },
+        flavors: { type: "array" },
+        comments: { type: "string" },
+        createdAt: { type: "string", format: "date-time" },
       },
-      required: ["id"]
+      required: ["id"],
     };
     const data = {
       status: 201,
       data: {
         createdAt: "2021-01-12T22:32:28.199Z",
-        flavors: [
-          "portuguesa"
-        ],
+        flavors: ["portuguesa"],
         comments: "comentarios",
-        status: "pending"
-      }
+        status: "pending",
+      },
     };
 
     const resultError = ajvValidator.validateResult(schema, data);
@@ -381,23 +373,21 @@ describe("validateResult", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string"},
-        qty: {type: "number"},
-        status: {type: "string"},
-        flavors: {type: "array"},
-        comments: {type: "string"},
-        createdAt: {type: "string", format: "date-time"}
+        id: { type: "string" },
+        qty: { type: "number" },
+        status: { type: "string" },
+        flavors: { type: "array" },
+        comments: { type: "string" },
+        createdAt: { type: "string", format: "date-time" },
       },
     };
     const data = {
       id: "5",
       createdAt: "2021-01-12T22:32:28.199Z",
       qty: 1,
-      flavors: [
-        "portuguesa"
-      ],
+      flavors: ["portuguesa"],
       comments: "comentarios",
-      status: "pending"
+      status: "pending",
     };
 
     const resultError = ajvValidator.validateResult(schema, data);
@@ -408,24 +398,22 @@ describe("validateResult", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string"},
-        qty: {type: "number"},
-        status: {type: "string"},
-        flavors: {type: "array"},
-        comments: {type: "string"},
-        createdAt: {type: "string", format: "date-time"}
+        id: { type: "string" },
+        qty: { type: "number" },
+        status: { type: "string" },
+        flavors: { type: "array" },
+        comments: { type: "string" },
+        createdAt: { type: "string", format: "date-time" },
       },
-      required: ["id"]
+      required: ["id"],
     };
     const data = {
       id: "5",
       createdAt: "2021-01-12T22:32:28.199Z",
       qty: 1,
-      flavors: [
-        "portuguesa"
-      ],
+      flavors: ["portuguesa"],
       comments: "comentarios",
-      status: "pending"
+      status: "pending",
     };
 
     const resultError = ajvValidator.validateResult(schema, data);
@@ -436,22 +424,20 @@ describe("validateResult", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string"},
-        qty: {type: "number"},
-        status: {type: "string"},
-        flavors: {type: "array"},
-        comments: {type: "string"},
-        createdAt: {type: "string", format: "date-time"}
+        id: { type: "string" },
+        qty: { type: "number" },
+        status: { type: "string" },
+        flavors: { type: "array" },
+        comments: { type: "string" },
+        createdAt: { type: "string", format: "date-time" },
       },
-      required: ["id"]
+      required: ["id"],
     };
     const data = {
       createdAt: "2021-01-12T22:32:28.199Z",
-      flavors: [
-        "portuguesa"
-      ],
+      flavors: ["portuguesa"],
       comments: "comentarios",
-      status: "pending"
+      status: "pending",
     };
 
     const resultError = ajvValidator.validateResult(schema, data);
@@ -466,21 +452,21 @@ describe("validateResult", () => {
         input: {
           type: "object",
           properties: {
-            email: {type: "string", format: "email"},
-            password: {type: "string"},
-            save_password: {type: "boolean"}
+            email: { type: "string", format: "email" },
+            password: { type: "string" },
+            save_password: { type: "boolean" },
           },
-          required: ["email", "password"]
-        }
+          required: ["email", "password"],
+        },
       },
-      required: ["input"]
+      required: ["input"],
     };
     const data = {
       input: {
         email: "didi_moco@gmail.com",
         password: "trapalhoes",
-        save_password: true
-      }
+        save_password: true,
+      },
     };
 
     const resultError = ajvValidator.validateResult(schema, data);
@@ -494,23 +480,23 @@ describe("validateResult", () => {
         input: {
           type: "object",
           properties: {
-            email: {type: "string", format: "email"},
-            password: {type: "string"},
-            save_password: {type: "boolean"}
+            email: { type: "string", format: "email" },
+            password: { type: "string" },
+            save_password: { type: "boolean" },
           },
-          required: ["email", "password"]
-        }
+          required: ["email", "password"],
+        },
       },
-      required: ["input"]
+      required: ["input"],
     };
     const data = {
       data: {
         input: {
           email: "didi_moco@gmail.com",
           password: "trapalhoes",
-          save_password: true
-        }
-      }
+          save_password: true,
+        },
+      },
     };
 
     const resultError = ajvValidator.validateResult(schema, data);
@@ -524,20 +510,20 @@ describe("validateResult", () => {
         input: {
           type: "object",
           properties: {
-            email: {type: "string", format: "email"},
-            password: {type: "string"},
-            save_password: {type: "boolean"}
+            email: { type: "string", format: "email" },
+            password: { type: "string" },
+            save_password: { type: "boolean" },
           },
-          required: ["email", "password"]
-        }
+          required: ["email", "password"],
+        },
       },
-      required: ["input"]
+      required: ["input"],
     };
     const data = {
       input: {
         email: "didi_moco@gmail.com",
-        save_password: true
-      }
+        save_password: true,
+      },
     };
 
     const resultError = ajvValidator.validateResult(schema, data);
@@ -547,52 +533,51 @@ describe("validateResult", () => {
 });
 
 describe("validateTimeInterval", () => {
-
   test("Pass with date type number", () => {
     const input = {
-      id: '3d2f6ce3-ed63-40aa-89bb-048fed01c15c',
+      id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
       date: 120,
-      resource_type: 'ActivityManager'
-    }
+      resource_type: "ActivityManager",
+    };
     const resultError = ajvValidator.validateTimeInterval(input);
     expect(resultError).toBeUndefined();
   });
 
   test("Pass with date type dateTime", () => {
     const input = {
-      id: '3d2f6ce3-ed63-40aa-89bb-048fed01c15c',
-      date: '2022-05-13T00:00:00',
-      resource_type: 'ActivityManager'
-    }
+      id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
+      date: "2022-05-13T00:00:00",
+      resource_type: "ActivityManager",
+    };
     const resultError = ajvValidator.validateTimeInterval(input);
     expect(resultError).toBeUndefined();
   });
 
   test("Throw error with invalid date type", () => {
     const input = {
-      id: '3d2f6ce3-ed63-40aa-89bb-048fed01c15c',
-      date: '120',
-      resource_type: 'ActivityManager'
-    }
+      id: "3d2f6ce3-ed63-40aa-89bb-048fed01c15c",
+      date: "120",
+      resource_type: "ActivityManager",
+    };
     try {
       ajvValidator.validateTimeInterval(input);
     } catch (resultError) {
       expect(resultError).toBeDefined();
     }
   });
-})
+});
 
 describe("validateActivityManager", () => {
   test("Pass with a valid schema", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string"},
-        qty: {type: "number"},
-        status: {type: "string"},
-        flavors: {type: "array"},
-        comments: {type: "string"},
-        createdAt: {type: "string", format: "date-time"}
+        id: { type: "string" },
+        qty: { type: "number" },
+        status: { type: "string" },
+        flavors: { type: "array" },
+        comments: { type: "string" },
+        createdAt: { type: "string", format: "date-time" },
       },
     };
 
@@ -600,72 +585,77 @@ describe("validateActivityManager", () => {
       id: "5",
       qty: 1,
       status: "pending",
-      flavors: [
-        "portuguesa"
-      ],
+      flavors: ["portuguesa"],
       comments: "comentarios",
-      createdAt: "2021-01-12T22:32:28.199Z"  
+      createdAt: "2021-01-12T22:32:28.199Z",
     };
-  
+
     const resultError = ajvValidator.validateActivityManager(schema, data);
     expect(resultError).toBeUndefined();
   });
-   
+
+  test("Pass with an empty object", () => {
+    const schema = {};
+    const data = {
+      id: "5",
+      qty: 1,
+    };
+
+    const resultError = ajvValidator.validateActivityManager(schema, data);
+    expect(resultError).toBeUndefined();
+  });
+
   test("Throw error without required property id", () => {
     const schema = {
       type: "object",
       properties: {
-        id: {type: "string"},
-        qty: {type: "number"},
-        status: {type: "string"},
-        flavors: {type: "array"},
-        comments: {type: "string"},
-        createdAt: {type: "string", format: "date-time"}
+        id: { type: "string" },
+        qty: { type: "number" },
+        status: { type: "string" },
+        flavors: { type: "array" },
+        comments: { type: "string" },
+        createdAt: { type: "string", format: "date-time" },
       },
-      required: ["id"]
+      required: ["id"],
     };
 
     const data = {
       qty: 1,
       status: "pending",
-      flavors: [
-        "portuguesa"
-      ],
+      flavors: ["portuguesa"],
       comments: "comentarios",
-      createdAt: "2021-01-12T22:32:28.199Z"  
+      createdAt: "2021-01-12T22:32:28.199Z",
     };
-  
+
     const resultError = () => ajvValidator.validateActivityManager(schema, data);
     expect(resultError).toThrowError("data must have required property 'id'");
   });
-  
+
   test("Should rebuild schema if no type object is defined", () => {
     const schema = {
       properties: {
-        id: {type: "string"},
-        qty: {type: "number"},
-        status: {type: "string"},
-        flavors: {type: "array"},
-        comments: {type: "string"},
-        createdAt: {type: "string", format: "date-time"}
+        id: { type: "string" },
+        qty: { type: "number" },
+        status: { type: "string" },
+        flavors: { type: "array" },
+        comments: { type: "string" },
+        createdAt: { type: "string", format: "date-time" },
       },
     };
-    
+
     const data = {
       id: "5",
       qty: 1,
       status: "pending",
-      flavors: [
-        "portuguesa"
-      ],
+      flavors: ["portuguesa"],
       comments: "comentarios",
-      createdAt: "2021-01-12T22:32:28.199Z"  
+      createdAt: "2021-01-12T22:32:28.199Z",
     };
-  
+
     const resultError = ajvValidator.validateActivityManager(schema, data);
     expect(resultError).toBeUndefined();
   });
-   
+
   test("Pass with required in nested items", () => {
     const schema = {
       type: "object",
@@ -673,27 +663,27 @@ describe("validateActivityManager", () => {
         input: {
           type: "object",
           properties: {
-            email: {type: "string", format: "email"},
-            password: {type: "string"},
-            save_password: {type: "boolean"}
+            email: { type: "string", format: "email" },
+            password: { type: "string" },
+            save_password: { type: "boolean" },
           },
-          required: ["email", "password"]
-        }
+          required: ["email", "password"],
+        },
       },
-      required: ["input"]
+      required: ["input"],
     };
     const data = {
       input: {
         email: "didi_moco@gmail.com",
         password: "trapalhoes",
-        save_password: true
-      }
+        save_password: true,
+      },
     };
-  
+
     const resultError = ajvValidator.validateActivityManager(schema, data);
     expect(resultError).toBeUndefined();
-  }); 
-  
+  });
+
   test("Throw error with required in nested items", () => {
     const schema = {
       type: "object",
@@ -701,22 +691,22 @@ describe("validateActivityManager", () => {
         input: {
           type: "object",
           properties: {
-            email: {type: "string", format: "email"},
-            password: {type: "string"},
-            save_password: {type: "boolean"}
+            email: { type: "string", format: "email" },
+            password: { type: "string" },
+            save_password: { type: "boolean" },
           },
-          required: ["email", "password"]
-        }
+          required: ["email", "password"],
+        },
       },
-      required: ["input"]
+      required: ["input"],
     };
     const data = {
       input: {
         email: "didi_moco@gmail.com",
-        save_password: true
-      }
+        save_password: true,
+      },
     };
-  
+
     const resultError = () => ajvValidator.validateActivityManager(schema, data);
     expect(resultError).toThrowError("data/input must have required property 'password'");
   });
@@ -725,14 +715,14 @@ describe("validateActivityManager", () => {
     const schema = {
       type: "object",
       properties: {
-        dt: { type: "string", format: "date" }
+        dt: { type: "string", format: "date" },
       },
-      required: ['dt']
+      required: ["dt"],
     };
     const data = {
-      dt: "2021-19-12"
+      dt: "2021-19-12",
     };
-  
+
     const resultError = () => ajvValidator.validateActivityManager(schema, data);
     expect(resultError).toThrowError('data/dt must match format "date"');
   });

--- a/src/core/workflow/nodes/startProcess.js
+++ b/src/core/workflow/nodes/startProcess.js
@@ -88,7 +88,7 @@ class StartProcessSystemTaskNode extends SystemTaskNode {
         bag: this._setBag(bag, result),
         external_input: external_input,
         result: result,
-        error: null,
+        error: result.error,
         status: status,
         next_node_id: this.next(result),
         time_elapsed: time_elapsed,
@@ -101,6 +101,13 @@ class StartProcessSystemTaskNode extends SystemTaskNode {
   }
 
   async _run(execution_data) {
+    const { Workflow } = require("../workflow");
+    const workflow = await Workflow.fetchWorkflowByName(execution_data.workflow_name);
+    if (!workflow) {
+      emitter.emit("NODE.RESULT_ERROR", `WORKFLOW NAME ${execution_data.workflow_name} NOT FOUND`, {});
+      return [{ process_id: "", error: "workflow not found" }, ProcessStatus.ERROR];
+    }
+
     const process = await process_manager.createProcessByWorkflowName(
       execution_data.workflow_name,
       execution_data.actor_data,

--- a/src/engine/tests/integration/engine_processes.test.js
+++ b/src/engine/tests/integration/engine_processes.test.js
@@ -420,7 +420,7 @@ test("run process that creaters another process", async () => {
 });
 
 test("child process has restricted input schema", async () => {
-  const engine = new Engine(...settings.persist_options);
+  //const engine = new Engine(...settings.persist_options);
 
   const childWorkflow = await engine.saveWorkflow(
     "restricted_schema",
@@ -729,7 +729,7 @@ describe("User task timeout", () => {
 });
 
 test("Commit activity only on type 'commit' activity manager", async () => {
-  const engine = new Engine(...settings.persist_options);
+  //const engine = new Engine(...settings.persist_options);
   await engine.saveWorkflow("sample", "sample", blueprints_.notify_and_user_task);
 
   let process = await engine.createProcessByWorkflowName("sample", actors_.simpleton);
@@ -810,7 +810,7 @@ test("Push activity should return error to an non-existant activity manager", as
 test("Beat won't break despite orphan timer", async () => {
   const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-  const engine = new Engine(...settings.persist_options);
+  //const engine = new Engine(...settings.persist_options);
   const workflow = await engine.saveWorkflow(
     "user_timeout_one_hour",
     "user_timeout_one_hour",

--- a/src/engine/tests/integration/engine_processes.test.js
+++ b/src/engine/tests/integration/engine_processes.test.js
@@ -35,7 +35,6 @@ test("Workflow should not work with missing requirements", async () => {
 });
 
 test("Engine create process", async () => {
-  //const engine = new Engine(...settings.persist_options);
   const workflow = await engine.saveWorkflow("sample", "sample", blueprints_.minimal);
   const process = await engine.createProcess(workflow.id, actors_.simpleton);
   expect(process.id).toBeDefined();
@@ -43,7 +42,6 @@ test("Engine create process", async () => {
 });
 
 test("Engine create process without permission", async () => {
-  //const engine = new Engine(...settings.persist_options);
   const workflow = await engine.saveWorkflow("sample", "sample", blueprints_.admin_identity_user_task);
   const process = await engine.createProcess(workflow.id, actors_.simpleton);
   expect(process.id).toBeUndefined();
@@ -51,7 +49,6 @@ test("Engine create process without permission", async () => {
 });
 
 test("Engine create process by workflow name", async () => {
-  //const engine = new Engine(...settings.persist_options);
   await engine.saveWorkflow("sample", "sample", blueprints_.minimal);
   const process = await engine.createProcessByWorkflowName("sample", actors_.simpleton);
   expect(process.id).toBeDefined();
@@ -59,7 +56,6 @@ test("Engine create process by workflow name", async () => {
 });
 
 test("Engine create process without permission by workflow name", async () => {
-  //const engine = new Engine(...settings.persist_options);
   await engine.saveWorkflow("sample", "sample", blueprints_.admin_identity_user_task);
   const process = await engine.createProcessByWorkflowName("sample", actors_.simpleton);
   expect(process.id).toBeUndefined();
@@ -67,7 +63,6 @@ test("Engine create process without permission by workflow name", async () => {
 });
 
 test("Engine create process with data", async () => {
-  //const engine = new Engine(...settings.persist_options);
   await engine.saveWorkflow("sample", "sample", blueprints_.start_with_data);
   const create_data = { number: 9999, name: "createName" };
   let process = await engine.createProcessByWorkflowName("sample", actors_.simpleton, create_data);
@@ -79,7 +74,6 @@ test("Engine create process with data", async () => {
 });
 
 test("Engine create process with missing data but run fails", async () => {
-  //const engine = new Engine(...settings.persist_options);
   await engine.saveWorkflow("sample", "sample", blueprints_.start_with_data);
   const create_data = {};
   let process = await engine.createProcessByWorkflowName("sample", actors_.simpleton, create_data);
@@ -94,8 +88,6 @@ test("Engine create process with missing data but run fails", async () => {
 });
 
 describe("Run existing process", () => {
-  //const engine = new Engine(...settings.persist_options);
-
   async function createProcess(blueprint, actor_data) {
     const workflow = await engine.saveWorkflow("sample", "sample", blueprint);
     return await engine.createProcess(workflow.id, actor_data);
@@ -260,7 +252,6 @@ describe("Run existing process", () => {
 });
 
 test("process state notifier", async () => {
-  //const engine = new Engine(...settings.persist_options);
   try {
     const workflow = await engine.saveWorkflow("sample", "sample", blueprints_.minimal);
 
@@ -281,7 +272,6 @@ test("process state notifier", async () => {
 });
 
 test("activity manager notifier on run process", async () => {
-  //const engine = new Engine(...settings.persist_options);
   try {
     const workflow = await engine.saveWorkflow("sample", "sample", blueprints_.identity_user_task);
 
@@ -301,7 +291,6 @@ test("activity manager notifier on run process", async () => {
 });
 
 test("activity manager notifier on activity commit", async () => {
-  //const engine = new Engine(...settings.persist_options);
   try {
     const workflow = await engine.saveWorkflow("sample", "sample", blueprints_.identity_user_task);
 
@@ -332,7 +321,6 @@ test("run process using environment", async () => {
   const original_env_payload = process.env.PAYLOAD;
   const original_env_limit = process.env.LIMIT;
 
-  //const engine = new Engine(...settings.persist_options);
   try {
     process.env.ENVIRONMENT = "test";
     process.env.API_HOST = "https://koa-app:3000/test_api";
@@ -388,7 +376,6 @@ test("run process using environment", async () => {
 });
 
 test("run process that creaters another process", async () => {
-  //const engine = new Engine(...settings.persist_options);
   try {
     const minimal_workflow = await engine.saveWorkflow("minimal", "minimal", blueprints_.minimal);
     const create_process_workflow = await engine.saveWorkflow(
@@ -420,8 +407,6 @@ test("run process that creaters another process", async () => {
 });
 
 test("child process has restricted input schema", async () => {
-  //const engine = new Engine(...settings.persist_options);
-
   const childWorkflow = await engine.saveWorkflow(
     "restricted_schema",
     "child process with restricted input schema",
@@ -447,31 +432,7 @@ test("child process has restricted input schema", async () => {
   expect(childState.state.status).not.toBe(ProcessStatus.ERROR);
 });
 
-// test("run process that abort another process", async () => {
-//   const engine = new Engine(...settings.persist_options);
-//
-//   const user_task_workflow = await engine.saveWorkflow("user_task", "user_task", blueprints_.identity_user_task);
-//   const abort_process_workflow = await engine.saveWorkflow("abort_process_minimal", "abort_process_minimal", blueprints_.abort_process_minimal);
-//
-//   let user_task_process = await engine.createProcess(user_task_workflow.id, actors_.simpleton);
-//   user_task_process = await engine.runProcess(user_task_process.id, actors_.simpleton);
-//   expect(user_task_process.state.status).toEqual(ProcessStatus.WAITING);
-//
-//   let abort_process = await engine.createProcess(abort_process_workflow.id, actors_.simpleton, {
-//     process_list: [
-//       user_task_process.id,
-//       uuid(),
-//     ]
-//   });
-//   abort_process = await engine.runProcess(abort_process.id, actors_.simpleton);
-//   expect(abort_process.state.status).toEqual(ProcessStatus.FINISHED);
-//
-//   user_task_process = await engine.fetchProcess(user_task_process.id);
-//   expect(user_task_process.state.status).toEqual(ProcessStatus.INTERRUPTED);
-// });
-
 describe("User task timeout", () => {
-  //const engine = new Engine(...settings.persist_options);
   let actualTimeout;
   function wait(ms = 2000) {
     return new Promise((resolve) => {
@@ -729,7 +690,6 @@ describe("User task timeout", () => {
 });
 
 test("Commit activity only on type 'commit' activity manager", async () => {
-  //const engine = new Engine(...settings.persist_options);
   await engine.saveWorkflow("sample", "sample", blueprints_.notify_and_user_task);
 
   let process = await engine.createProcessByWorkflowName("sample", actors_.simpleton);
@@ -757,7 +717,6 @@ test("Commit activity only on type 'commit' activity manager", async () => {
 });
 
 test("Push activity only on type 'commit' activity manager", async () => {
-  //const engine = new Engine(...settings.persist_options);
   await engine.saveWorkflow("sample", "sample", blueprints_.notify_and_2_user_task);
 
   let process = await engine.createProcessByWorkflowName("sample", actors_.simpleton);
@@ -809,8 +768,6 @@ test("Push activity should return error to an non-existant activity manager", as
 
 test("Beat won't break despite orphan timer", async () => {
   const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-  //const engine = new Engine(...settings.persist_options);
   const workflow = await engine.saveWorkflow(
     "user_timeout_one_hour",
     "user_timeout_one_hour",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
StartProcessNode checks whether the workflow name exists before trying to create a new process.
Simplify ajvValidator to accept an empty object

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125 #124 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/fdte-dsd/community/contributors/dev/guide/release_notes.md
-->
```release-note
Changes de error response when a StartProcess Node refers to a non-existing workflow
```

**Additional documentation e.g., usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
