### PR TITLE
Refactor input prepare() 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "mustache": "4.2.0",
         "pg": "8.8.0",
         "qs": "6.11.0",
+        "safe-eval": "^0.4.1",
         "traceparent": "1.0.0",
         "uuid": "8.3.2",
         "winston": "3.8.2"
@@ -11680,6 +11681,11 @@
         }
       ]
     },
+    "node_modules/safe-eval": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/safe-eval/-/safe-eval-0.4.1.tgz",
+      "integrity": "sha512-wmiu4RSYVZ690RP1+cv/LxfPK1dIlEN35aW7iv4SMYdqDrHbkll4+NJcHmKm7PbCuI1df1otOcPwgcc2iFR85g=="
+    },
     "node_modules/safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -22283,6 +22289,11 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-eval": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/safe-eval/-/safe-eval-0.4.1.tgz",
+      "integrity": "sha512-wmiu4RSYVZ690RP1+cv/LxfPK1dIlEN35aW7iv4SMYdqDrHbkll4+NJcHmKm7PbCuI1df1otOcPwgcc2iFR85g=="
     },
     "safe-regex": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "mustache": "4.2.0",
     "pg": "8.8.0",
     "qs": "6.11.0",
+    "safe-eval": "^0.4.1",
     "traceparent": "1.0.0",
     "uuid": "8.3.2",
     "winston": "3.8.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mustache": "4.2.0",
     "pg": "8.8.0",
     "qs": "6.11.0",
-    "safe-eval": "^0.4.1",
+    "safe-eval": "0.4.1",
     "traceparent": "1.0.0",
     "uuid": "8.3.2",
     "winston": "3.8.2"

--- a/src/core/utils/input.js
+++ b/src/core/utils/input.js
@@ -2,6 +2,7 @@
 const _ = require("lodash");
 const mustache = require("mustache");
 const handlebars = require("handlebars");
+const safeEval = require("safe-eval");
 const crypto_manager = require("../crypto_manager");
 
 
@@ -46,7 +47,7 @@ function prepare(source, context = {}, interpreters = {}) {
 
   const operators = {
     $ref: (sourceContent, context) => _.get(context, sourceContent),
-    $js: (sourceContent, context) => eval(sourceContent)(_.cloneDeep(context)),
+    $js: (sourceContent, context) => safeEval(sourceContent)(_.cloneDeep(context)),
     $mustache: (sourceContent, context) => mustache.render(sourceContent, context),
     $handlebars: (sourceContent, context) => handlebars.compile(sourceContent)(context),
     $minimal: (sourceContent, context, interpreters) => interpreters['$minimal'].eval(["let", _.flatten(Object.entries(context)), sourceContent]),

--- a/src/core/utils/input.js
+++ b/src/core/utils/input.js
@@ -26,74 +26,76 @@ handlebars.registerHelper("div", function (a, b) {
 });
 
 function prepare(source, context = {}, interpreters = {}) {
-  let last_result;
-  if (source && typeof source === "object") {
-    if (source instanceof Array) {
-      last_result = source.map((item) => prepare(item, context));
-    } else {
-      let op;
-      for (let key of Object.keys(source)) {
-        if (key[0] === "$") {
-          if (op) {
-            throw new Error("More than one '$' found");
-          }
-          op = key;
-        }
-      }
 
-      switch (op) {
-        case "$ref": {
-          last_result = _.get(context, source[op]);
-          break;
-        }
-        case "$mustache": {
-          last_result = mustache.render(source[op], context);
-          break;
-        }
-        case "$handlebars": {
-          const template = handlebars.compile(source[op]);
-          last_result = template(context);
-          break;
-        }
-        case "$js": {
-          const contextCopy = _.cloneDeep(context);
-          last_result = eval(source[op])(contextCopy);
-          break;
-        }
-        case "$minimal": {
-          const contextCopy = _.cloneDeep(context);
-          const listKeyValues = _.flatten(Object.entries(contextCopy));
-          last_result = interpreters[op].eval(["let", listKeyValues, source[op]]);
-          break;
-        }
-        case "$decrypt": {
-          const crypto = crypto_manager.getCrypto();
-          const crypted_value = _.get(context, source[op]);
-          last_result = crypto.decrypt(crypted_value);
-          break;
-        }
-        case "$map": {
-          const { array, value } = source[op];
-          const list = prepare(array, context, interpreters);
-          if (list instanceof Array) {
-            last_result = list.map((item) => prepare(value, item));
-          } else {
-            last_result = list;
-          }
-          break;
-        }
-        default: {
-          last_result = {};
-          for (let [key, value] of Object.entries(source)) {
-            last_result[key] = prepare(value, context);
-          }
-          break;
-        }
-      }
-    }
-  } else {
-    last_result = source;
+  if (!source || typeof source !== "object") {
+    return source
   }
+
+  if (source instanceof Array) {
+    return source.map((item) => prepare(item, context));
+  }
+
+  let last_result;
+  let op;
+  for (let key of Object.keys(source)) {
+    if (key[0] === "$") {
+      if (op) {
+        throw new Error("More than one '$' found");
+      }
+      op = key;
+    }
+  }
+
+  switch (op) {
+    case "$ref": {
+      last_result = _.get(context, source[op]);
+      break;
+    }
+    case "$mustache": {
+      last_result = mustache.render(source[op], context);
+      break;
+    }
+    case "$handlebars": {
+      const template = handlebars.compile(source[op]);
+      last_result = template(context);
+      break;
+    }
+    case "$js": {
+      const contextCopy = _.cloneDeep(context);
+      last_result = eval(source[op])(contextCopy);
+      break;
+    }
+    case "$minimal": {
+      const contextCopy = _.cloneDeep(context);
+      const listKeyValues = _.flatten(Object.entries(contextCopy));
+      last_result = interpreters[op].eval(["let", listKeyValues, source[op]]);
+      break;
+    }
+    case "$decrypt": {
+      const crypto = crypto_manager.getCrypto();
+      const crypted_value = _.get(context, source[op]);
+      last_result = crypto.decrypt(crypted_value);
+      break;
+    }
+    case "$map": {
+      const { array, value } = source[op];
+      const list = prepare(array, context, interpreters);
+      if (list instanceof Array) {
+        last_result = list.map((item) => prepare(value, item));
+      } else {
+        last_result = list;
+      }
+      break;
+    }
+    default: {
+      last_result = {};
+      for (let [key, value] of Object.entries(source)) {
+        last_result[key] = prepare(value, context);
+      }
+      break;
+    }
+  }
+
   return last_result;
 }
 

--- a/src/core/utils/input.js
+++ b/src/core/utils/input.js
@@ -36,17 +36,13 @@ function prepare(source, context = {}, interpreters = {}) {
   }
 
   let last_result;
-  let op;
-  for (let key of Object.keys(source)) {
-    if (key[0] === "$") {
-      if (op) {
-        throw new Error("More than one '$' found");
-      }
-      op = key;
-    }
+  const op = Object.keys(source).filter(key => key[0] === "$")
+
+  if(op.length > 1){
+    throw new Error("More than one '$' found");
   }
 
-  switch (op) {
+  switch (op[0]) {
     case "$ref": {
       last_result = _.get(context, source[op]);
       break;

--- a/src/core/utils/input.js
+++ b/src/core/utils/input.js
@@ -60,14 +60,14 @@ function prepare(source, context = {}, interpreters = {}) {
 
   const processor = operators[op]
 
-  if(typeof processor === 'undefined'){
+  if (typeof processor === 'undefined') {
     return Object.keys(source).reduce((obj, key) => ({ ...obj, [key]: prepare(source[key], context, interpreters) }), {})
   }
 
-  try{
+  try {
     return processor(source[op], context, interpreters);
-  }catch(cause){
-    throw new Error(`Error while evaluating ${op}: ${source[op]}\n${cause.message}`, {cause})
+  } catch (cause) {
+    throw new Error(`Error while evaluating ${op}: ${source[op]}\n${cause.message}`, { cause })
   }
 }
 

--- a/src/core/utils/input.js
+++ b/src/core/utils/input.js
@@ -67,7 +67,7 @@ function prepare(source, context = {}, interpreters = {}) {
   try{
     return processor(source[op], context, interpreters);
   }catch(cause){
-    throw new Error(`Error while evaluating ${op}: ${source[op]}`, {cause})
+    throw new Error(`Error while evaluating ${op}: ${source[op]}\n${cause.message}`, {cause})
   }
 }
 

--- a/src/core/utils/tests/unitary/input.test.js
+++ b/src/core/utils/tests/unitary/input.test.js
@@ -162,7 +162,6 @@ describe("prepare", () => {
         })
     });
 
-
     describe("$js", () => {
         it("javascript simple", () => {
             const source = {
@@ -563,5 +562,22 @@ describe("prepare", () => {
                 ]
             });
         });
+    });
+
+    describe("error msgs", () => {
+        it("malformed js", () => {
+            const source = {
+                $js: "() => undefined.foo()"
+            };
+            expect(() => prepare(source)).toThrow(Error);
+        })
+
+        it("malformed object", () => {
+            const source = {
+                $js: "() => 2 + 2",
+                $handlebars: "simple string"
+            };
+            expect(() => prepare(source)).toThrow(Error);
+        })
     });
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/fdte-dsd/community/contributors/guide.#your_first_contribution and developer guide https://github.com/fdte-dsd/community/contributors/dev/guide.md#development_guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/fdte-dsd/community/contributors/dev/guide#labeling_pr_for_release
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/fdte-dsd/community/contributors/dev/guide#tests
-->

**What type of PR is this?**
/kind design

**What this PR does / why we need it**:
Refactor the input prepare() function and improves its error messages

**Does this PR introduce a user-facing change?**:

When the preparation of a node fails, the generated error is specific of the node js crash and lacks the context of the cause of the crash

For example, if a blueprint contains a node with an entry

```js
{
    $js: "() => undefined.foo()"
}
```

The generated error would be `TypeError: Cannot read properties of undefined (reading 'foo')`, which is true but lacks the context of the error, which is the evaluation of a `$js` operator

This PR improves the error message by prepending the context where the error occurred (i.e. evaluation of input operator) and taking leverage of [node js Error API](https://nodejs.org/api/errors.html) by defining the generic error as cause of the specific one 

The shown example would became

```
Error: Error while evaluating $js: () => undefined.foo()
Cannot read properties of undefined (reading 'foo')
    at prepare (/usr/app/src/core/utils/input.js:70:11)
    at Object.<anonymous> (/usr/app/src/core/utils/tests/unitary/input.test.js:575:17)
    ... 5 lines matching cause stack trace ...
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  [cause]: TypeError: Cannot read properties of undefined (reading 'foo')
```
