### PR TITLE
Fix silent failure when target process creates notify activity manager

### DIFF
--- a/src/core/workflow/activity_manager.js
+++ b/src/core/workflow/activity_manager.js
@@ -187,7 +187,7 @@ class ActivityManager extends PersistedEntity {
     for (const activity_manager_data of full_activity_manager_data) {
       const activity_manager = ActivityManager.deserialize(activity_manager_data);
       activity_manager.activities = activity_manager_data.activities;
-      await activity_manager._validateActivity(process_id);
+      await activity_manager._validateActivity(process_id, trx);
     }
   }
 
@@ -293,10 +293,10 @@ class ActivityManager extends PersistedEntity {
     return this;
   }
 
-  async _validateActivity(process_id) {
+  async _validateActivity(process_id, trx) {
     //ToDo
     this._status = ActivityStatus.COMPLETED;
-    await this.save();
+    await this.save(trx);
     emitter.emit("ACTIVITY_MANAGER.COMPLETED", `ACTIVITY MANAGER COMPLETED AMID: [${this.id}]`, {
       activity_manager: this,
     });

--- a/src/core/workflow/process.js
+++ b/src/core/workflow/process.js
@@ -729,7 +729,7 @@ class Process extends PersistedEntity {
 
   // eslint-disable-next-line no-unused-vars
   async _executionLoop(custom_lisp, actor_data, input_trx = false, skipLock = false) {
-    
+
     if(!skipLock) {
       const isLocked = await this.checkForSwitch(input_trx);
       if(isLocked) {
@@ -793,6 +793,10 @@ class Process extends PersistedEntity {
         });
         await this._notifyActivityManager(activity_manager);
       }
+    }
+
+    if(execution_success){
+      input_trx.commit()
     }
 
     if (activity_manager) {

--- a/src/core/workflow/process.js
+++ b/src/core/workflow/process.js
@@ -795,7 +795,7 @@ class Process extends PersistedEntity {
       }
     }
 
-    if(execution_success){
+    if(execution_success && input_trx){
       input_trx.commit()
     }
 

--- a/src/core/workflow/process.js
+++ b/src/core/workflow/process.js
@@ -304,7 +304,7 @@ class Process extends PersistedEntity {
           actor_data,
           null
         );
-        await this.save();
+        await this.save(trx);
         await this._notifyProcessState({});
       }
 

--- a/src/core/workflow/process.js
+++ b/src/core/workflow/process.js
@@ -813,7 +813,7 @@ class Process extends PersistedEntity {
         await ActivityManager.finishActivityManagerForProcess(this._id, input_trx);
         break;
       case ProcessStatus.FORBIDDEN:
-        await ActivityManager.finishActivityManagerForProcess(this._id);
+        await ActivityManager.finishActivityManagerForProcess(this._id, input_trx);
         break;
     }
 

--- a/src/core/workflow/target.js
+++ b/src/core/workflow/target.js
@@ -121,7 +121,7 @@ class Target extends PersistedEntity {
     let process;
     switch(this.resource_type) {
       case 'workflow':
-        const db = Target.getPersist()._db;
+        const db = trx ? trx : Target.getPersist()._db;
         await db.transaction(async (inner_trx) => {
           try {
             process = await createProcessByWorkflowId(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/fdte-dsd/community/contributors/guide.#your_first_contribution and developer guide https://github.com/fdte-dsd/community/contributors/dev/guide.md#development_guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/fdte-dsd/community/contributors/dev/guide#labeling_pr_for_release
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/fdte-dsd/community/contributors/dev/guide#tests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When a signal starts a process that creates a new notify activity manager, the application breaks. This PR partially fixes this problem

The logic is still flawed, as the engine tries do save the same Activity Manager twice and breaks, but now at least the execution of the process goes until the end

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
