### PR TITLE
Improve robustness of environment variables evaluation

### DIFF
--- a/src/core/utils/environment.js
+++ b/src/core/utils/environment.js
@@ -1,0 +1,35 @@
+const { VM } = require('vm2');
+
+module.exports.readEnvironmentVariableAsBool = function (varname, default_value) {
+  const raw = process.env[varname]
+
+  if (typeof raw === 'undefined') {
+    return default_value
+  }
+
+  try {
+    return !!new VM().run(raw)
+  } catch (cause) {
+    throw new Error(
+      `Error while evaluating env ${varname} as bool, should be valid JS expression`,
+      { cause }
+    )
+  }
+}
+
+module.exports.readEnvironmentVariableAsNumber = function (varname, default_value) {
+  const raw = process.env[varname]
+
+  if (typeof raw === 'undefined') {
+    return default_value
+  }
+
+  try {
+    return Number(raw)
+  } catch (cause) {
+    throw new Error(
+      `Error while evaluating env ${varname} as number, should be valid JS expression`,
+      { cause }
+    )
+  }
+}

--- a/src/core/utils/eventEmitter.js
+++ b/src/core/utils/eventEmitter.js
@@ -1,4 +1,5 @@
 const logUtil = require("./logging");
+const { readEnvironmentVariableAsBool } = require('./environment');
 
 module.exports = function startEventListener(em) {
   em.on("KNEX.*", (message, variables) => {
@@ -252,7 +253,7 @@ module.exports = function startEventListener(em) {
   });
 
   em.on("HTTP.NODE.*", (message, variable) => {
-    if(process.env.HTTP_NODE_LOG === "true") {
+    if(readEnvironmentVariableAsBool('HTTP_NODE_LOG', false)) {
       const obj = {
         level: variable?.level || 'info',
         message: `[PID ${variable.process_id}] - ${JSON.stringify(message)}`,

--- a/src/engine/engine.js
+++ b/src/engine/engine.js
@@ -18,6 +18,7 @@ const { ProcessStatus } = require("./../core/workflow/process_state");
 const { validateTimeInterval } = require("../core/utils/ajvValidator");
 const { validate: uuidValidate } = require("uuid");
 const { isEmpty } = require("lodash");
+const { readEnvironmentVariableAsBool, readEnvironmentVariableAsNumber } = require('../core/utils/environment');
 
 function getActivityManagerFromData(activity_manager_data) {
   const activity_manager = ActivityManager.deserialize(activity_manager_data);
@@ -55,7 +56,7 @@ class Engine {
   }
 
   constructor(persist_mode, persist_args, logger_level) {
-    const heartBeat = process.env.ENGINE_HEARTBEAT || true;
+    const heartBeat = readEnvironmentVariableAsBool('ENGINE_HEARTBEAT', true);
     createLogger(logger_level);
     if (Engine.instance) {
       startEventListener(emitter);
@@ -65,7 +66,7 @@ class Engine {
     this._db = persist_args;
     Engine.instance = this;
     this.emitter = emitter;
-    if (heartBeat === true || heartBeat === "true") {
+    if (heartBeat) {
       try {
         Engine.heart = Engine.setNextHeartBeat();
         emitter.emit("ENGINE.CONTRUCTOR", "HEARTBEAT INITIALIZED", {});
@@ -172,7 +173,7 @@ class Engine {
         Engine.heart = Engine.setNextHeartBeat();
         emitter.emit("ENGINE.NEXT", "NEXT HEARTBEAT SET");
       }
-    }, process.env.HEART_BEAT || 1000);
+    }, readEnvironmentVariableAsNumber('HEART_BEAT', 1000));
   }
 
   static kill() {


### PR DESCRIPTION
Follow up from #245 

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
There are several environment variables used to configure the engine's behavior treated as boolean value. Currently, they are evaluated as `true` (or logically enabled) if, and only if, they match the literal string 'true'. This leads to unexpected behavior when other values logically equivalent to `true` (e.g. `1`) are passed

This PR changes the evaluation logic from config environment variables. Now, any valid javascript expression may be evaluated into a boolean value, in according to javascript semantics. If an invalid expression is passed, the application throws an error, signaling that an invalid config file was passed 

This PR also drops the dependency from `safe-eval`, as it is considered unsecure to evaluate text as javascript code

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
