### PR TITLE
fix: adjust subprocess node in case workflow doesnt exist

### DIFF
--- a/src/core/workflow/nodes/subProcess.js
+++ b/src/core/workflow/nodes/subProcess.js
@@ -63,7 +63,7 @@ class SubProcessNode extends ParameterizedNode {
     return {
       workflow_name: prepared_workflow_name,
       input: prepared_input,
-      actor_data: prepared_actor_data,
+      actor_data: { ...prepared_actor_data, ...{ parentProcessData: { id: parameters.process_id } } },
     };
   }
 
@@ -83,7 +83,8 @@ class SubProcessNode extends ParameterizedNode {
           parent_process_data: {
             id: parameters.process_id,
             expected_step_number: input.step_number + 1,
-          }
+          },
+          ...execution_data.input
         }
 
         const child_process = await process_manager.createProcessByWorkflowName(

--- a/src/core/workflow/nodes/subProcess.js
+++ b/src/core/workflow/nodes/subProcess.js
@@ -94,11 +94,19 @@ class SubProcessNode extends ParameterizedNode {
 
         let result, status;
         if (child_process?.id) {
+          emitter.emit(
+            "PROCESS.SUBPROCESS",
+            `      NEW SUBPROCESS ON PID [${parameters.process_id}] SPID [${child_process?.id}]`,
+            {
+              process_id: parameters.process_id,
+              sub_process_id: child_process.id,
+            }
+          );
           process_manager.runProcess(child_process.id, execution_data.actor_data);
           result = { sub_process_id: child_process.id };
           status = ProcessStatus.DELEGATED;
         } else {
-          emitter.emit("NODE.RESULT_ERROR", `WORKFLOW ${execution_data.workflow_name} NOT FOUND`, {});
+          emitter.emit("NODE.RESULT_ERROR", `WORKFLOW NAME ${execution_data.workflow_name} NOT FOUND`, {});
           result = { sub_process_id: "", error: "workflow not found" };
           status = ProcessStatus.ERROR;
         }

--- a/src/core/workflow/nodes/subProcess.js
+++ b/src/core/workflow/nodes/subProcess.js
@@ -5,6 +5,8 @@ const { prepare } = require("../../utils/input");
 const { ProcessStatus } = require("../process_state");
 const crypto_manager = require("../../crypto_manager");
 const { ParameterizedNode } = require("./parameterized");
+const process_manager = require("../process_manager");
+const emitter = require("../../utils/emitter");
 
 class SubProcessNode extends ParameterizedNode {
   static get schema() {
@@ -39,6 +41,32 @@ class SubProcessNode extends ParameterizedNode {
     return SubProcessNode.validate(this._spec);
   }
 
+  _preProcessing({ bag, input, actor_data, environment, parameters }) {
+    const context = {
+      bag,
+      result: input,
+      actor_data,
+      environment,
+      parameters,
+    };
+
+    const prepared_input = super._preProcessing({
+      bag,
+      input,
+      actor_data,
+      environment,
+      parameters,
+    });
+    const prepared_workflow_name = prepare(this._spec.parameters.workflow_name, context);
+    const prepared_actor_data = prepare(this._spec.parameters.actor_data, context);
+
+    return {
+      workflow_name: prepared_workflow_name,
+      input: prepared_input,
+      actor_data: prepared_actor_data,
+    };
+  }
+
   async run({ bag, input, external_input = null, actor_data, environment = {}, parameters = {} }, lisp) {
     try {
       if (!external_input) {
@@ -51,13 +79,37 @@ class SubProcessNode extends ParameterizedNode {
           parameters,
         });
 
+        const initial_bag = {
+          parent_process_data: {
+            id: parameters.process_id,
+            expected_step_number: input.step_number + 1,
+          }
+        }
+
+        const child_process = await process_manager.createProcessByWorkflowName(
+          execution_data.workflow_name,
+          execution_data.actor_data,
+          initial_bag
+        );
+
+        let result, status;
+        if (child_process?.id) {
+          process_manager.runProcess(child_process.id, execution_data.actor_data);
+          result = { sub_process_id: child_process.id };
+          status = ProcessStatus.DELEGATED;
+        } else {
+          emitter.emit("NODE.RESULT_ERROR", `WORKFLOW ${execution_data.workflow_name} NOT FOUND`, {});
+          result = { sub_process_id: "", error: "workflow not found" };
+          status = ProcessStatus.ERROR;
+        }
+
         return {
           node_id: this.id,
           bag: bag,
           external_input: external_input, //external_input is always null here
-          result: execution_data,
+          result: result,
           error: null,
-          status: ProcessStatus.DELEGATED,
+          status: status,
           next_node_id: this.id,
           workflow_name: this._spec.parameters.workflow_name,
           actor_data: prepared_actor_data,

--- a/src/core/workflow/process.js
+++ b/src/core/workflow/process.js
@@ -554,32 +554,6 @@ class Process extends PersistedEntity {
           process_id: p_lock.id,
           activity_manager_id: am.id,
         });
-      } else if (result_state.status === ProcessStatus.DELEGATED) {
-        emitter.emit("PROCESS.SUBPROCESS.CREATING", `      CREATING NEW SUBPROCESS ON PID [${p_lock.id}]`, {
-          process_id: p_lock.id,
-          sub_workflow_name: node_result.workflow_name,
-        });
-        const initial_bag = result_state.result;
-        const parent_data = {
-          id: this.id,
-          expected_step_number: result_state.step_number,
-        };
-        initial_bag.parent_process_data = parent_data;
-        const child_process = await process_manager.createProcessByWorkflowName(
-          node_result.workflow_name,
-          node_result.actor_data,
-          initial_bag
-        );
-        if (child_process.status === ProcessStatus.UNSTARTED) {
-          emitter.emit("PROCESS.SUBPROCESS.NEW", `NEW SUBPROCESS ON PID [${p_lock.id}] SPID [${child_process.id}]`, {
-            process_id: p_lock.id,
-            sub_process_id: child_process.id,
-          });
-
-          process_manager.runProcess(child_process.id, node_result.actor_data, {});
-        } else {
-          throw new Error(`ERROR CREATING SUBPROCESS`);
-        }
       } else if (result_state.status === ProcessStatus.FINISHED) {
         emitter.emit("PROCESS.FINISHED", `      FINISHED PID [${p_lock.id}]`, {
           process_id: p_lock.id,

--- a/src/core/workflow/process_manager.js
+++ b/src/core/workflow/process_manager.js
@@ -30,7 +30,7 @@ async function continueProcess(process_id, result_data, expected_step_number, tr
 
 async function createProcessByWorkflowName(workflow_name, actor_data, initial_bag = {}) {
   const workflow = await workflowDependency.Workflow.fetchWorkflowByName(workflow_name);
-  if (workflow) {
+  if (workflow?.id) {
     return await workflow.createProcess(actor_data, initial_bag);
   }
   return undefined;


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it:**

When a SubProcess Node try to create a process for a workflow_name that doesn't exist the engine goes into a continue process of ROLLBACK ON EXEC and the parent_process keeps in state DELEGATED.

This PR adjusts that by setting the state of the process as ERROR when the workflow_name doesn't exist (along with some refactoring)

**Which issue(s) this PR fixes:**

Fixes #
